### PR TITLE
Updated loading-single-entity example to use letter b instead of s in…

### DIFF
--- a/content/efcore/getting-started/samples/loading-single-entity/Program.cs
+++ b/content/efcore/getting-started/samples/loading-single-entity/Program.cs
@@ -9,7 +9,7 @@ public class Program
         using (var context = new LibraryContext())
         {
             var book = context.Books
-                .Single(s => s.BookId == 1);
+                .Single(b => b.BookId == 1);
             Console.WriteLine(book.Title);
         }
     }


### PR DESCRIPTION
… LINQ statement