### PR TITLE
49 markdown tables not generated properly

### DIFF
--- a/content/efcore/getting-started/README.md
+++ b/content/efcore/getting-started/README.md
@@ -18,3 +18,4 @@ This tutorial will cover the following topics:
 - [Querying Data](querying.md)
 - [Loading Related Data](loading-related-data.md)
 - [Manipulating Entities](manipulating-entities.md)
+- [Database Reference](tutorial-database-reference.md)

--- a/content/efcore/getting-started/README.md
+++ b/content/efcore/getting-started/README.md
@@ -18,4 +18,5 @@ This tutorial will cover the following topics:
 - [Querying Data](querying.md)
 - [Loading Related Data](loading-related-data.md)
 - [Manipulating Entities](manipulating-entities.md)
-- [Database Reference](tutorial-database-reference.md)
+- [Appendix: Database Reference](tutorial-database-reference.md)
+- [Appendix: Data Model Reference](tutorial-model-reference.md)

--- a/content/efcore/getting-started/toc.md
+++ b/content/efcore/getting-started/toc.md
@@ -3,4 +3,5 @@
 - [Querying Data](querying.md)
 - [Loading Related Data](loading-related-data.md)
 - [Manipulating Entities](manipulating-entities.md)
-- [Database Reference](tutorial-database-reference.md)
+- [Appendix: Database Reference](tutorial-database-reference.md)
+- [Appendix: Data Model Reference](tutorial-model-reference.md)

--- a/content/efcore/getting-started/toc.md
+++ b/content/efcore/getting-started/toc.md
@@ -3,4 +3,4 @@
 - [Querying Data](querying.md)
 - [Loading Related Data](loading-related-data.md)
 - [Manipulating Entities](manipulating-entities.md)
-- [Database Reference](manipulating-entities.md)
+- [Database Reference](tutorial-database-reference.md)

--- a/content/efcore/getting-started/toc.md
+++ b/content/efcore/getting-started/toc.md
@@ -3,3 +3,4 @@
 - [Querying Data](querying.md)
 - [Loading Related Data](loading-related-data.md)
 - [Manipulating Entities](manipulating-entities.md)
+- [Database Reference](manipulating-entities.md)

--- a/content/efcore/getting-started/tutorial-database-reference.md
+++ b/content/efcore/getting-started/tutorial-database-reference.md
@@ -2,16 +2,16 @@
  
 ## Authors  
  
-| AuthorId | FirstName  | LastName  |  
-|----------|------------|-----------|  
-| 1        | Jack       | London    |  
-| 2        | Mark       | Twain     |  
-| 3        | Willa      | Cather    |   
-| 4        | Frederick  | Douglass  |  
-| 7        | Agatha     | Christie  |  
-| 8        | Virginia   | Woolf     |  
-| 9        | Frances    | Harper    |  
-| 10       | Stephen    | Crane     |  
+ AuthorId | FirstName  | LastName  
+----------|------------|-----------
+ 1        | Jack       | London    
+ 2        | Mark       | Twain     
+ 3        | Willa      | Cather     
+ 4        | Frederick  | Douglass  
+ 7        | Agatha     | Christie  
+ 8        | Virginia   | Woolf     
+ 9        | Frances    | Harper    
+ 10       | Stephen    | Crane     
  
 ## Books  
  

--- a/content/efcore/getting-started/tutorial-database-reference.md
+++ b/content/efcore/getting-started/tutorial-database-reference.md
@@ -1,4 +1,4 @@
-# Database Tables 
+# Database Reference
  
 ## Authors  
  

--- a/content/efcore/getting-started/tutorial-database-reference.md
+++ b/content/efcore/getting-started/tutorial-database-reference.md
@@ -1,34 +1,34 @@
-# Database Reference
+# Appendix: Database Reference
  
 ## Authors  
  
- AuthorId | FirstName  | LastName  
-----------|------------|-----------
- 1        | Jack       | London    
- 2        | Mark       | Twain     
- 3        | Willa      | Cather     
- 4        | Frederick  | Douglass  
- 7        | Agatha     | Christie  
- 8        | Virginia   | Woolf     
- 9        | Frances    | Harper    
- 10       | Stephen    | Crane     
+AuthorId | FirstName  | LastName  
+---------|------------|----------
+1        | Jack       | London    
+2        | Mark       | Twain     
+3        | Willa      | Cather     
+4        | Frederick  | Douglass  
+7        | Agatha     | Christie  
+8        | Virginia   | Woolf     
+9        | Frances    | Harper    
+10       | Stephen    | Crane     
  
 ## Books  
  
-| BookId | AuthorId | Title                           | Genre            | PublicationYear |  
-|--------|----------|---------------------------------|------------------|-----------------|  
-| 1      | 9        | Mrs Dalloway                   | Literary         | 1925            |  
-| 2      | 1        | The Scarlet Plague              | Science Fiction  | 1912            |  
-| 3      | 8        | The Secret Adversary            | Mystery          | 1922            |  
-| 4      | 5        | My Bondage and My Freedom       | Narrative        | 1855            |  
-| 5      | 4        | My Antonia                      | Historical       | 1918            |  
-| 6      | 4        | O Pioneers!                     | Historical       | 1913            |  
-| 7      | 2        | Adventures of Huckleberry Finn  | Satire           | 1884            |  
-| 8      | 2        | The Adventures of Tom Sawyer    | Satire           | 1876            |  
-| 9      | 10       | Iola Leroy                      | Historical       | 1892            |  
-| 10     | 8        | Murder on the Orient Express    | Mystery          | 1934            |  
-| 11     | 1        | The Call of the Wild            | Adventure        | 1903            |  
-| 12     | 4        | Death Comes for the Archbishop  | Historical       | 1927            |  
+BookId | AuthorId | Title                           | Genre            | PublicationYear
+-------|----------|---------------------------------|------------------|----------------
+1      | 9        | Mrs Dalloway                    | Literary         | 1925           
+2      | 1        | The Scarlet Plague              | Science Fiction  | 1912           
+3      | 8        | The Secret Adversary            | Mystery          | 1922           
+4      | 5        | My Bondage and My Freedom       | Narrative        | 1855           
+5      | 4        | My Antonia                      | Historical       | 1918           
+6      | 4        | O Pioneers!                     | Historical       | 1913           
+7      | 2        | Adventures of Huckleberry Finn  | Satire           | 1884           
+8      | 2        | The Adventures of Tom Sawyer    | Satire           | 1876           
+9      | 10       | Iola Leroy                      | Historical       | 1892           
+10     | 8        | Murder on the Orient Express    | Mystery          | 1934           
+11     | 1        | The Call of the Wild            | Adventure        | 1903           
+12     | 4        | Death Comes for the Archbishop  | Historical       | 1927           
      
 ## Editions 
  


### PR DESCRIPTION
The tables are edited in PR 59, but this branch adds the reference pages to the toc so it doesn't error when you click on the links to the pages.

Only edited the first two tables because the second two are being deleted by PR 59
Resolves #49 